### PR TITLE
Change the default view for Facets

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -14,7 +14,7 @@ import {
   Sorting,
   WithSearch
 } from "@elastic/react-search-ui";
-import { Layout, SingleLinksFacet } from "@elastic/react-search-ui-views";
+import { Layout } from "@elastic/react-search-ui-views";
 import "@elastic/react-search-ui-views/lib/styles/styles.css";
 
 import {

--- a/src/App.js
+++ b/src/App.js
@@ -61,12 +61,7 @@ export default function App() {
                         />
                       )}
                       {getFacetFields().map(field => (
-                        <Facet
-                          key={field}
-                          field={field}
-                          label={field}
-                          view={SingleLinksFacet}
-                        />
+                        <Facet key={field} field={field} label={field} />
                       ))}
                     </div>
                   }


### PR DESCRIPTION
The "SingleLinksFacet" view does not have a "more" button, which breaks the Reference UI for users.

<img width="1676" alt="App_Search_Reference_UI" src="https://user-images.githubusercontent.com/1427475/64208309-8e422480-ce6c-11e9-8e7a-68f361d73bbd.png">
