### PR TITLE
[PR] - Reading searchkey from environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ Run the following commands to start this application:
 # below with the actual path of your project.
 cd ~/Downloads/app-search-reference-ui
 
+#Run this command to save the searchKey as an envrionment variable. This is required to Reference UI to connect to App Search. Replace the search key with the actual key from the App Search credentials section.
+export REACT_APP_APPSEARCH_SEARCHKEY=search-XXXXXXXXXXXXXXXXXXXXXXX
+
 # Run this to set everything up
 npm install
 

--- a/src/App.js
+++ b/src/App.js
@@ -26,9 +26,9 @@ import {
   getFacetFields
 } from "./config/config-helper";
 
-const { hostIdentifier, searchKey, endpointBase, engineName } = getConfig();
+const { hostIdentifier, endpointBase, engineName } = getConfig();
 const connector = new AppSearchAPIConnector({
-  searchKey,
+  searchKey: process.env.REACT_APP_APPSEARCH_SEARCHKEY,
   engineName,
   hostIdentifier,
   endpointBase


### PR DESCRIPTION
This is related to https://github.com/elastic/app-search-reference-ui-react/issues/82.

The user would save the `searchKey` as an environment variable rather than saved in the clear in the JSON file.